### PR TITLE
Fix type 2 subdivision

### DIFF
--- a/penrose.js
+++ b/penrose.js
@@ -64,8 +64,8 @@ function GenerateTypeTwo(count) {
 			}
 			else {
 				var p = math.add(triangle.c, math.subtract(triangle.a, triangle.c).div(goldenRatio));
-				result.push(createTriangle(0, triangle.b, p, triangle.a));
-				result.push(createTriangle(1, p , triangle.c , triangle.b ));				
+				result.push(createTriangle(1, triangle.b, p, triangle.a));
+				result.push(createTriangle(0, p , triangle.c , triangle.b ));
 			}
 		});
 		triangleSet = result;


### PR DESCRIPTION
If the “type 2” was supposed to be the kite and dart Penrose tiling, then there was an error in the coloring of the decomposition of the half-dart tile. This has led to an incorrect subdivision when the number of iterations whas higher than 2.